### PR TITLE
Use envvar INFLUX_URL instead of hard-coding urls in template configs

### DIFF
--- a/docs/submit_a_template.md
+++ b/docs/submit_a_template.md
@@ -27,6 +27,8 @@ To contribute a new template or enhance an existing template, submit a pull requ
 
     * To update an existing template, make the changes to template files in the appropriate directory.
 
+    > **Tip:** Replace any hard-coded URLs to InfluxDB in your Telegraf configurations with the `$INFLUX_URL` environment variable so users can easily point it to their own InfluxDB instance location. For example: `urls = ["$INFLUX_URL"]`
+
 3. Add and commit your changes and push them to Github. Include the `--signoff` flag when committing your changes to include your author information in the commit message.
 
     ```

--- a/linux_system/README.md
+++ b/linux_system/README.md
@@ -18,6 +18,7 @@ This InfluxDB Template can be used to monitor your Linux System.
     
   - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your master token to get started.
   - `INFLUX_ORG` - The name of your Organization (this will be your email address on the InfluxDB Cloud free tier)
+  - `INFLUX_URL` - The URL of your InfluxDB host (this can your localhost, a remote instance, or InfluxDB Cloud)
 
   You **MUST** set these environment variables before running Telegraf using something similar to the following commands
     

--- a/linux_system/linux_system.yml
+++ b/linux_system/linux_system.yml
@@ -252,7 +252,7 @@ spec:
           ## Multiple URLs can be specified for a single cluster, only ONE of the
           ## urls will be written to each interval.
           ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
-          urls = ["http://127.0.0.1:9999"]
+          urls = ["$INFLUX_URL"]
           ## Token for authentication.
           token = "$INFLUX_TOKEN"
           ## Organization is the name of the organization you wish to write to; must exist.

--- a/monitoring_influxdb_1.x/README.md
+++ b/monitoring_influxdb_1.x/README.md
@@ -21,6 +21,7 @@ This InfluxDB Template can be used to monitor your already running InfluxDB 1.x 
     
   - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your master token to get started.
   - `INFLUX_ORG` - The name of your Organization
+  - `INFLUX_URL` - The URL of your InfluxDB host (this can your localhost, a remote instance, or InfluxDB Cloud)
 
   You **MUST** set these environment variables before running Telegraf using something similar to the following commands
     

--- a/monitoring_influxdb_1.x/influxdb1.x.yml
+++ b/monitoring_influxdb_1.x/influxdb1.x.yml
@@ -317,7 +317,7 @@ spec:
           ##
           ## Multiple URLs can be specified for a single cluster, only ONE of the
           ## urls will be written to each interval.
-          urls = ["http://localhost:9999"]
+          urls = ["$INFLUX_URL"]
 
           ## Token for authentication.
           token = "$INFLUX_TOKEN"


### PR DESCRIPTION
This will allow Telegraf configurations in the Templates to be run without modification and still point to the location of a user's InfluxDB instance

Signed-off-by: Michael Hall <mhall119@gmail.com>