### PR TITLE
Use INFLUX_HOST envvar to match the influx CLI

### DIFF
--- a/linux_system/README.md
+++ b/linux_system/README.md
@@ -18,7 +18,7 @@ This InfluxDB Template can be used to monitor your Linux System.
     
   - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your master token to get started.
   - `INFLUX_ORG` - The name of your Organization (this will be your email address on the InfluxDB Cloud free tier)
-  - `INFLUX_URL` - The URL of your InfluxDB host (this can your localhost, a remote instance, or InfluxDB Cloud)
+  - `INFLUX_HOST` - The URL of your InfluxDB host (this can your localhost, a remote instance, or InfluxDB Cloud)
 
   You **MUST** set these environment variables before running Telegraf using something similar to the following commands
     

--- a/linux_system/linux_system.yml
+++ b/linux_system/linux_system.yml
@@ -252,7 +252,7 @@ spec:
           ## Multiple URLs can be specified for a single cluster, only ONE of the
           ## urls will be written to each interval.
           ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
-          urls = ["$INFLUX_URL"]
+          urls = ["$INFLUX_HOST"]
           ## Token for authentication.
           token = "$INFLUX_TOKEN"
           ## Organization is the name of the organization you wish to write to; must exist.

--- a/monitoring_influxdb_1.x/README.md
+++ b/monitoring_influxdb_1.x/README.md
@@ -21,7 +21,7 @@ This InfluxDB Template can be used to monitor your already running InfluxDB 1.x 
     
   - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your master token to get started.
   - `INFLUX_ORG` - The name of your Organization
-  - `INFLUX_URL` - The URL of your InfluxDB host (this can your localhost, a remote instance, or InfluxDB Cloud)
+  - `INFLUX_HOST` - The URL of your InfluxDB host (this can your localhost, a remote instance, or InfluxDB Cloud)
 
   You **MUST** set these environment variables before running Telegraf using something similar to the following commands
     

--- a/monitoring_influxdb_1.x/influxdb1.x.yml
+++ b/monitoring_influxdb_1.x/influxdb1.x.yml
@@ -317,7 +317,7 @@ spec:
           ##
           ## Multiple URLs can be specified for a single cluster, only ONE of the
           ## urls will be written to each interval.
-          urls = ["$INFLUX_URL"]
+          urls = ["$INFLUX_HOST"]
 
           ## Token for authentication.
           token = "$INFLUX_TOKEN"


### PR DESCRIPTION
Replaces the use of $INFLUX_URL in Telegraf configurations with $INFLUX_HOST so they will use the same environment variables as the `influx pkg` command 

Signed-off-by: Michael Hall <mhall119@gmail.com>
