### PR TITLE
Fix all metadata.name fields to be DNS-1123 compliant. Fixes #96

### DIFF
--- a/currency_exchange_rates/currency_exchange_rates.yml
+++ b/currency_exchange_rates/currency_exchange_rates.yml
@@ -2,36 +2,41 @@
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: Exchange Rates
+    name: exchange-rates
 spec:
+    name: Exchange Rates
     color: '#7A65F2'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: outputs-influxdb-v2
+spec:
     name: outputs.influxdb_v2
-spec:
     color: '#108174'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: inputs-http
+spec:
     name: inputs.http
-spec:
     color: '#108174'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: processors-regex
+spec:
     name: processors.regex
-spec:
     color: '#108174'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: processors.pivot
+    name: processors-pivot
 spec:
+    name: processors.pivot
     color: '#108174'
 ---
 apiVersion: influxdata.com/v2alpha1
@@ -39,6 +44,7 @@ kind: Bucket
 metadata:
     name: quandl
 spec:
+    name: quandl
     retentionRules:
       - everySeconds: 2592000
         type: expire
@@ -46,17 +52,18 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Telegraf
 metadata:
-    name: Exchange Rates Data Retrieval
+    name: exchange-rates-data-retrieval
 spec:
+    name: Exchange Rates Data Retrieval
     associations:
       - kind: Label
-        name: outputs.influxdb_v2
+        name: outputs-influxdb-v2
       - kind: Label
-        name: inputs.http
+        name: inputs-http
       - kind: Label
-        name: processors.regex
+        name: processors-regex
       - kind: Label
-        name: processors.pivot
+        name: processors-pivot
     config: |
         [agent]
           interval = "1m"
@@ -122,8 +129,9 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
 metadata:
-    name: Exchange Rates
+    name: exchange-rates
 spec:
+    name: Exchange Rates
     charts:
       - axes:
           - base: "10"

--- a/influxdb2_oss_metrics/influxdb2_oss_metrics.yml
+++ b/influxdb2_oss_metrics/influxdb2_oss_metrics.yml
@@ -1,8 +1,9 @@
 apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 metadata:
-    name: oss_metrics
+    name: oss-metrics
 spec:
+    name: oss_metrics
     retentionRules:
       - everySeconds: 604800
         type: expire
@@ -10,8 +11,9 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: InfluxDB2
+    name: influxdb2
 spec:
+    name: InfluxDB2
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
@@ -19,16 +21,18 @@ kind: Label
 metadata:
     name: prometheus
 spec:
+    name: prometheus
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
 metadata:
-    name: InfluxDB OSS Metrics
+    name: influxdb-oss-metrics
 spec:
+    name: InfluxDB OSS Metrics
     associations:
       - kind: Label
-        name: InfluxDB2
+        name: influxdb2
       - kind: Label
         name: prometheus
     charts:

--- a/jenkins/jenkins.yml
+++ b/jenkins/jenkins.yml
@@ -567,9 +567,6 @@ kind: Dashboard
 metadata:
     name: zen-taussig-127001
 spec:
-    associations:
-      - kind: Label
-        name: festive-jemison-127001
     charts:
       - colors:
           - hex: '#00C9FF'
@@ -715,9 +712,6 @@ kind: Telegraf
 metadata:
     name: wiggitty-huh-127001
 spec:
-    associations:
-      - kind: Label
-        name: festive-jemison-127001
     config: |
         # Telegraf Configuration
         #

--- a/linux_system/linux_system.yml
+++ b/linux_system/linux_system.yml
@@ -1,78 +1,89 @@
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: Linux System Template
+    name: linux-system-template
 spec:
+    name: Linux System Template
     color: '#7A65F2'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: inputs-cpu
+spec:
     name: inputs.cpu
-spec:
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: inputs-disk
+spec:
     name: inputs.disk
-spec:
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: inputs-diskio
+spec:
     name: inputs.diskio
-spec:
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: inputs-kernel
+spec:
     name: inputs.kernel
-spec:
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: inputs-mem
+spec:
     name: inputs.mem
-spec:
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: inputs-net
+spec:
     name: inputs.net
-spec:
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: inputs-processes
+spec:
     name: inputs.processes
-spec:
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: inputs-swap
+spec:
     name: inputs.swap
-spec:
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
+    name: inputs-system
+spec:
     name: inputs.system
-spec:
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: outputs.influxdb_v2
+    name: outputs-influxdb-v2
 spec:
+    name: outputs.influxdb_v2
     color: '#108174'
 ---
 apiVersion: influxdata.com/v2alpha1
@@ -80,6 +91,7 @@ kind: Bucket
 metadata:
     name: telegraf
 spec:
+    name: telegraf
     retentionRules:
       - everySeconds: 604800
         type: expire
@@ -89,9 +101,10 @@ kind: Variable
 metadata:
     name: bucket
 spec:
+    name: bucket
     associations:
       - kind: Label
-        name: Linux System Template
+        name: linux-system-template
     language: flux
     query: |-
         buckets()
@@ -103,11 +116,12 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Variable
 metadata:
-    name: linux_host
+    name: linux-host
 spec:
+    name: linux_host
     associations:
       - kind: Label
-        name: Linux System Template
+        name: linux-system-template
     language: flux
     query: |-
         import "influxdata/influxdb/v1"
@@ -117,31 +131,32 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Telegraf
 metadata:
-    name: Linux System Monitoring
+    name: linux-system-monitoring
 spec:
+    name: Linux System Monitoring
     associations:
       - kind: Label
-        name: inputs.cpu
+        name: inputs-cpu
       - kind: Label
-        name: inputs.system
+        name: inputs-system
       - kind: Label
-        name: inputs.swap
+        name: inputs-swap
       - kind: Label
-        name: inputs.processes
+        name: inputs-processes
       - kind: Label
-        name: inputs.net
+        name: inputs-net
       - kind: Label
-        name: inputs.mem
+        name: inputs-mem
       - kind: Label
-        name: inputs.kernel
+        name: inputs-kernel
       - kind: Label
-        name: inputs.disk
+        name: inputs-disk
       - kind: Label
-        name: inputs.diskio
+        name: inputs-diskio
       - kind: Label
-        name: outputs.influxdb_v2
+        name: outputs-influxdb-v2
       - kind: Label
-        name: Linux System Template
+        name: linux-system-template
     config: |
         # Telegraf Configuration
         #
@@ -383,11 +398,12 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
 metadata:
-    name: Linux System
+    name: linux-system
 spec:
+    name: Linux System
     associations:
       - kind: Label
-        name: Linux System Template
+        name: linux-system-template
     charts:
       - height: 1
         kind: Markdown

--- a/modbus/modbus.yml
+++ b/modbus/modbus.yml
@@ -1023,7 +1023,7 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Telegraf
 metadata:
-    name: wiggitty_huh_127002
+    name: wiggitty-huh-127002
 spec:
     associations:
       - kind: Label
@@ -1239,4 +1239,4 @@ spec:
             { name = "WindFarm", byte_order = "AB",   data_type = "FLOAT32", scale=0.1,  address = [14]},
           ]
 
-      name: Modbus Monitor
+    name: Modbus Monitor

--- a/monitoring_influxdb_1.x/influxdb1.x.yml
+++ b/monitoring_influxdb_1.x/influxdb1.x.yml
@@ -1,22 +1,25 @@
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: InfluxDB1.x
+    name: influxdb1-x
 spec:
+    name: InfluxDB1.x
     color: '#311F94'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: Solution
+    name: solution
 spec:
+    name: Solution
     color: '#FFD255'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: Telegraf
+    name: telegraf
 spec:
+    name: Telegraf
     color: '#C9D0FF'
 ---
 apiVersion: influxdata.com/v2alpha1
@@ -24,6 +27,7 @@ kind: Bucket
 metadata:
     name: telegraf
 spec:
+    name: telegraf
     retentionRules:
       - everySeconds: 604800
         type: expire
@@ -31,8 +35,9 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: CheckDeadman
 metadata:
-    name: Host Deadman
+    name: host-deadman
 spec:
+    name: Host Deadman
     every: 1m0s
     level: CRIT
     query: |-
@@ -48,8 +53,9 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: CheckThreshold
 metadata:
-    name: Disk Usage Check
+    name: disk-usage-check
 spec:
+    name: Disk Usage Check
     every: 1m0s
     query: |-
         from(bucket: "telegraf")
@@ -73,8 +79,9 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: CheckThreshold
 metadata:
-    name: Memory Usage Check
+    name: memory-usage-check
 spec:
+    name: Memory Usage Check
     every: 1m0s
     query: |-
         from(bucket: "telegraf")
@@ -98,6 +105,7 @@ kind: Variable
 metadata:
     name: bucket
 spec:
+    name: bucket
     language: flux
     query: |-
         buckets()
@@ -109,8 +117,9 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Variable
 metadata:
-    name: influxdb_host
+    name: influxdb-host
 spec:
+    name: influxdb_host
     language: flux
     query: |-
         import "influxdata/influxdb/v1"
@@ -120,8 +129,9 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Variable
 metadata:
-    name: telegraf_host
+    name: telegraf-host
 spec:
+    name: telegraf_host
     language: flux
     query: |-
         import "influxdata/influxdb/v1"
@@ -131,15 +141,16 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Telegraf
 metadata:
-    name: InfluxDB_1.x.conf
+    name: influxdb-1-x-conf
 spec:
+    name: InfluxDB_1.x.conf
     associations:
       - kind: Label
-        name: Solution
+        name: solution
       - kind: Label
-        name: InfluxDB1.x
+        name: influxdb1-x
       - kind: Label
-        name: Telegraf
+        name: telegraf
     config: |
         # Global tags can be specified here in key="value" format.
         [global_tags]
@@ -366,13 +377,14 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
 metadata:
-    name: InfluxDB 1.x
+    name: influxdb-1-x
 spec:
+    name: InfluxDB 1.x
     associations:
       - kind: Label
-        name: Solution
+        name: solution
       - kind: Label
-        name: InfluxDB1.x
+        name: influxdb1-x
     charts:
       - colors:
           - hex: '#00C9FF'
@@ -1188,15 +1200,16 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
 metadata:
-    name: Telegraf
+    name: telegraf
 spec:
+    name: Telegraf
     associations:
       - kind: Label
-        name: Solution
+        name: solution
       - kind: Label
-        name: InfluxDB1.x
+        name: influxdb1-x
       - kind: Label
-        name: Telegraf
+        name: telegraf
     charts:
       - axes:
           - base: "10"

--- a/nginx_mysql/nginx_mysql.yml
+++ b/nginx_mysql/nginx_mysql.yml
@@ -370,9 +370,6 @@ kind: Telegraf
 metadata:
     name: wiggitty-huh-127001
 spec:
-    associations:
-      - kind: Label
-        name: festive-jemison-127001
     config: |
         # Telegraf Configuration
         #

--- a/telegraf/manifest.yml
+++ b/telegraf/manifest.yml
@@ -1,8 +1,9 @@
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
 metadata:
-    name: Telegraf
+    name: telegraf
 spec:
+    name: Telegraf
     charts:
       - colors:
           - hex: '#00C9FF'
@@ -515,8 +516,9 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Telegraf
 metadata:
-    name: Telegraf Internal Monitoring
+    name: telegraf-internal-monitoring
 spec:
+    name: Telegraf Internal Monitoring
     config: |
         [agent]
           interval = "10s"
@@ -543,8 +545,9 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 metadata:
-    name: Telegraf
+    name: telegraf
 spec:
+    name: Telegraf
     retentionRules:
       - everySeconds: 604800
         type: expire

--- a/windows_system/windows_system.yml
+++ b/windows_system/windows_system.yml
@@ -1,22 +1,25 @@
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: Windows System Template
+    name: windows-system-template
 spec:
+    name: Windows System Template
     color: '#7A65F2'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: inputs.win_perf_counters
+    name: inputs-win-perf-counters
 spec:
+    name: inputs.win_perf_counters
     color: '#326BBA'
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
-    name: outputs.influxdb_v2
+    name: outputs-influxdb-v2
 spec:
+    name: outputs.influxdb_v2
     color: '#108174'
 ---
 apiVersion: influxdata.com/v2alpha1
@@ -24,6 +27,7 @@ kind: Bucket
 metadata:
     name: telegraf
 spec:
+    name: telegraf
     retentionRules:
       - everySeconds: 604800
         type: expire
@@ -33,9 +37,10 @@ kind: Variable
 metadata:
     name: bucket
 spec:
+    name: bucket
     associations:
       - kind: Label
-        name: Windows System Template
+        name: windows-system-template
     language: flux
     query: |-
         buckets()
@@ -47,11 +52,12 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Variable
 metadata:
-    name: windows_host
+    name: windows-host
 spec:
+    name: windows_host
     associations:
       - kind: Label
-        name: Windows System Template
+        name: windows-system-template
     language: flux
     query: |-
         import "influxdata/influxdb/v1"
@@ -61,15 +67,16 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Telegraf
 metadata:
-    name: Windows System Monitoring
+    name: windows-system-monitoring
 spec:
+    name: Windows System Monitoring
     associations:
       - kind: Label
-        name: inputs.win_perf_counters
+        name: inputs-win-perf-counters
       - kind: Label
-        name: outputs.influxdb_v2
+        name: outputs-influxdb-v2
       - kind: Label
-        name: Windows System Template
+        name: windows-system-template
     config: |
         # Telegraf Configuration
         #
@@ -344,11 +351,12 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
 metadata:
-    name: Windows System
+    name: windows-system
 spec:
+    name: Windows System
     associations:
       - kind: Label
-        name: Windows System Template
+        name: windows-system-template
     charts:
       - height: 1
         kind: Markdown


### PR DESCRIPTION
With these changes, `influx pkg validate` passes for all yaml manifests