### PR TITLE
chore: update CLI command to use stable CLI API

### DIFF
--- a/Example_README.md
+++ b/Example_README.md
@@ -14,7 +14,7 @@ Provide a short description of your template and use case here. Try to keep it t
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/{your_template_dir}/{your_template_file}
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/{your_template_dir}/{your_template_file}
 ```
 
 ## Included Resources

--- a/InfluxDBv2_Covid19_SouthAmerica/readme.md
+++ b/InfluxDBv2_Covid19_SouthAmerica/readme.md
@@ -11,7 +11,7 @@ This Dashboard graph information about COVID-19 focused in Argentina, Bolivia, B
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/InfluxDBv2_Covid19_SouthAmerica/covid.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/InfluxDBv2_Covid19_SouthAmerica/covid.yml
 ```
 
 ## Included Resources

--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ You can also ask the community to create a template for a specific use-case by c
 
 Community InfluxDB templates are provided by members of the community. Template authors are solely responsible for supporting their templates. InfluxData does not test contributed templates, nor guarantee their quality or safety. If you have questions about or need help with a specific template, please contact the template author using the contact information provided in the template README.
 
-InfluxData provides and supports the `influx` command-line tool and `influx pkg` command for importing and exporting template manifests. You'll need the [InfluxDB 2.0.0 beta or greater](https://portal.influxdata.com/downloads/) for the `influx pkg` command. For help with these tools, please join our [Community Slack](https://influxdata.com/slack) and ask for help in the `#community-support` channel.
+InfluxData provides and supports the `influx` command-line tool and `influx apply` command for importing and exporting template manifests. You'll need the [InfluxDB 2.0.0 beta or greater](https://portal.influxdata.com/downloads/) for the `influx apply` command. For help with these tools, please join our [Community Slack](https://influxdata.com/slack) and ask for help in the `#community-support` channel.
 
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://www.influxdata.com/slack)

--- a/apache_postgresql/README.md
+++ b/apache_postgresql/README.md
@@ -9,7 +9,7 @@ This InfluxDB Template can be used to monitor a website running on Apache HTTPd 
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/apache_postgresql/website_template.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/apache_postgresql/website_template.yml
 ```
 
 ### Included Resources

--- a/aws_cloudwatch/README.md
+++ b/aws_cloudwatch/README.md
@@ -18,7 +18,7 @@ Provided by: [bonitoo.io](.)
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/aws_cloudwatch/aws_cloudwatch.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/aws_cloudwatch/aws_cloudwatch.yml
 ```
 
 ## Included Resources

--- a/csgo/readme.md
+++ b/csgo/readme.md
@@ -11,7 +11,7 @@ This Dashboard offers you information about your game in CSGO. Information about
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/csgo/csgo.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/csgo/csgo.yml
 ```
 
 ## Included Resources

--- a/currency_exchange_rates/README.md
+++ b/currency_exchange_rates/README.md
@@ -25,7 +25,7 @@ It also shows how to use functions such as [timedMovingAverage()](https://v2.doc
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/currency_exchange_rates/currency_exchange_rates.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/currency_exchange_rates/currency_exchange_rates.yml
 ```
 
 ## Included Resources

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ This InfluxDB Template can be used to monitor Docker.
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/docker/docker.yml
 ```
 
 ### Included Resources

--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -91,7 +91,7 @@ This will give the user a drop-down menu with all of the unique values of the ta
 [Labels](https://v2.docs.influxdata.com/v2.0/visualize-data/labels/) let you tag your resources for easier identification in the UI and make it easier to export resources into a Template. If you have a mix of resources in your InfluxDB instance you will have to individually specify which ones to export so that you don't export them all. However, if you use unique Labels to identify resources, you can filter resources by Label when exporting your Template:
 
 ```
-influx pkg export all --filter=labelName=your_label_name
+influx export all --filter=labelName=your_label_name
 ```
 
 ## Telegraf Configurations

--- a/docs/submit_a_template.md
+++ b/docs/submit_a_template.md
@@ -20,7 +20,7 @@ To contribute a new template or enhance an existing template, submit a pull requ
         Use the following command to export the template and generate a manifest file ([Influx pkg requires InfluxDB 2.0.0 beta or greater](https://portal.influxdata.com/downloads/)):
 
         ```
-        influx pkg export --file ~/path/to/template/manifest.yml
+        influx export --file ~/path/to/template/manifest.yml
         ```
 
         > Exported manifest files will be YAML or JSON. The filename extension you provide will determine the format used.

--- a/docs/use_a_template.md
+++ b/docs/use_a_template.md
@@ -8,7 +8,7 @@ Each template provides a manifest file and instructions for using the template.
 To import a template, use the following command:
 
 ```
- influx pkg --file ~/path/to/template/manifest.yml
+ influx apply --file ~/path/to/template/manifest.yml
 ```
 
 This imports the specified `manifest.yml` into an instance of InfluxDB running on `localhost`.
@@ -17,7 +17,7 @@ This imports the specified `manifest.yml` into an instance of InfluxDB running o
 
 If you don't want to download the manifest file locally, you can point to its remote location using the `--url` flag, for example:
 ```
- influx pkg --url https://raw.githubusercontent.com/influxdata/community-templates/master/template/manifest.yml
+ influx apply --url https://raw.githubusercontent.com/influxdata/community-templates/master/template/manifest.yml
  ```
 
 NOTE: Ensure that when pulling a file from Github, you will need to use the `raw` content link from the `Raw` button, not the URL of the file.
@@ -27,7 +27,7 @@ NOTE: Ensure that when pulling a file from Github, you will need to use the `raw
 If you are using InfluxDB Cloud, ensure that your Influx CLI is configured with your cloud account credentials and that configuration is active. See `influx config -h` or the [InfluxDB documentation](https://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/) for more details.
 
 ```
- influx pkg --file ~/path/to/template/manifest.yml
+ influx apply --file ~/path/to/template/manifest.yml
 ```
 
 > Your default organization name in InfluxDB Cloud will be your email address.
@@ -42,7 +42,7 @@ To apply templates and download Telegraf configurations from InfluxDB Cloud, cre
 If running InfluxDB on a remote server, provide the URL of your InfluxDB instance using the `--host` flag and provide your InfluxDB authentication token using the ``--token`` flag:
 
 ```
- influx pkg --file ~/path/to/template/manifest.yml
+ influx apply --file ~/path/to/template/manifest.yml
 ```
 
 

--- a/enviro_plus/README.md
+++ b/enviro_plus/README.md
@@ -11,7 +11,7 @@ View the air quality readings from a [Pimoroni Enviro+](https://shop.pimoroni.co
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/enviro_plus/enviro_plus.json
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/enviro_plus/enviro_plus.json
 ```
 
 ## Included Resources

--- a/gcp_monitoring/README.md
+++ b/gcp_monitoring/README.md
@@ -22,7 +22,7 @@ Cloud Monitoring API v3. There are three dashboards in this template.**
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/gcp_monitoring/gcp_monitoring.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/gcp_monitoring/gcp_monitoring.yml
 ```
 
 ## Included Resources
@@ -42,7 +42,7 @@ environment.
 
 An example command:
 ```bash
- $ ${INFLUX_PATH}/influx pkg --org qa --file ${myTemplateFile} -t ${INFLUX_TOKEN}
+ $ ${INFLUX_PATH}/influx apply --org qa --file ${myTemplateFile} -t ${INFLUX_TOKEN}
 ```
 
 Include the [Telegraf Stackdriver plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/stackdriver) in your Telegraf configuration and start Telegraf.

--- a/github/readme.md
+++ b/github/readme.md
@@ -11,7 +11,7 @@ This dashboard help you get metrics of your Github repository.
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/github/github.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/github/github.yml
 ```
 
 ## Included Resources

--- a/haproxy/readme.md
+++ b/haproxy/readme.md
@@ -11,7 +11,7 @@ This dashboard help you get metrics of your HAProxy instance.
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/haproxy/haproxy.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/haproxy/haproxy.yml
 ```
 
 ## Included Resources

--- a/influxdb2_oss_metrics/README.md
+++ b/influxdb2_oss_metrics/README.md
@@ -11,7 +11,7 @@ This InfluxDB Template can be used to monitor your already running InfluxDB 2 in
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/influxdb2_oss_metrics/influxdb2_oss_metrics.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/influxdb2_oss_metrics/influxdb2_oss_metrics.yml
 ```
 
 ## Included Resources

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -9,7 +9,7 @@ This InfluxDB Template can be used to montior a Jenkins instance
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/jenkins/jenkins.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/jenkins/jenkins.yml
 ```
 
 ### Included Resources

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -18,7 +18,7 @@ supports Google Cloud Platform, AWS and on-premise K8S environments.**
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/k8s/k8s.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/k8s/k8s.yml
 ```
 
 ## Included Resources

--- a/linux_system/README.md
+++ b/linux_system/README.md
@@ -9,7 +9,7 @@ This InfluxDB Template can be used to monitor your Linux System.
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/linux_system/linux_system.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/linux_system/linux_system.yml
 ```
 
 ### Included Resources

--- a/minio/readme.md
+++ b/minio/readme.md
@@ -11,7 +11,7 @@ This template allows you to monitor your MinIO instance. The data you can watch 
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/minio/minio.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/minio/minio.yml
 ```
 
 ## Included Resources

--- a/modbus/README.md
+++ b/modbus/README.md
@@ -12,7 +12,7 @@ The goal of this template is to provide an example of using Telgraf's Modbus inp
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/modbus/modbus.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/modbus/modbus.yml
 ```
 
 ### Included Resources

--- a/mongodb/readme.md
+++ b/mongodb/readme.md
@@ -11,7 +11,7 @@ This Dashboard offers you information about your MongoDB instance. Uptime, Conne
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/mongodb/mongodb.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/mongodb/mongodb.yml
 ```
 
 ## Included Resources

--- a/monitoring_influxdb_1.x/README.md
+++ b/monitoring_influxdb_1.x/README.md
@@ -11,7 +11,7 @@ This InfluxDB Template can be used to monitor your already running InfluxDB 1.x 
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/monitoring_influxdb_1.x/influxdb1.x.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/monitoring_influxdb_1.x/influxdb1.x.yml
 ```
 
 ## Included Resources

--- a/mssql/readme.md
+++ b/mssql/readme.md
@@ -11,7 +11,7 @@ This Dashboard offers you information about your Microsoft SQL Server. Uptime, C
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/mssql/mssql.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/mssql/mssql.yml
 ```
 
 ## Included Resources

--- a/mysql_mariadb/readme.md
+++ b/mysql_mariadb/readme.md
@@ -11,7 +11,7 @@ This Dashboard offers you information about your MySQL/MariaDB instance. Uptime,
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/mysql_mariadb/mysql_mariadb.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/mysql_mariadb/mysql_mariadb.yml
 ```
 
 ## Included Resources

--- a/network_interface_performance/README.md
+++ b/network_interface_performance/README.md
@@ -11,7 +11,7 @@ This InfluxDB Template can be used to monitor your network traffic across multip
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/network_interface_performance/network_interface_performance.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/network_interface_performance/network_interface_performance.yml
 ```
 
 ## Included Resources

--- a/nginx_mysql/README.md
+++ b/nginx_mysql/README.md
@@ -9,7 +9,7 @@ This InfluxDB Template can be used to monitor a website running on NGINX and MyS
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/nginx_mysql/nginx_mysql.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/nginx_mysql/nginx_mysql.yml
 ```
 
 ### Included Resources

--- a/postgresql/readme.md
+++ b/postgresql/readme.md
@@ -11,7 +11,7 @@ This Dashboard offers you information about your Postgres instance. CPU Usage, R
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/postgresql/postgres.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/postgresql/postgres.yml
 ```
 
 ## Included Resources

--- a/redis/README.md
+++ b/redis/README.md
@@ -9,7 +9,7 @@ This InfluxDB Template can be used to monitor Redis.
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/redis/redis.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/redis/redis.yml
 ```
 
 ### Included Resources

--- a/sflow/README.md
+++ b/sflow/README.md
@@ -11,7 +11,7 @@ This InfluxDB Template can be used to monitor traffic from sFlow sources.
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/sflow/sflow.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/sflow/sflow.yml
 ```
 
 ### Included Resources

--- a/snmp/README.md
+++ b/snmp/README.md
@@ -13,7 +13,7 @@ This template provides several dashboards showing metrics provided via SNMP prot
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/snmp/snmp.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/snmp/snmp.yml
 ```
 
 ## Included Resources

--- a/telegraf/README.md
+++ b/telegraf/README.md
@@ -11,7 +11,7 @@ Provided by: Steven Soroka
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/telegraf/manifest.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/telegraf/manifest.yml
 ```
 
 ## Included Resources
@@ -66,7 +66,7 @@ ___example___
 ```sh
 export TELEGRAF_MANIFEST_URL=https://raw.githubusercontent.com/influxdata/community-templates/master/telegraf/manifest.yml
 
-influx pkg --url $TELEGRAF_MANIFEST_URL \
+influx apply --url $TELEGRAF_MANIFEST_URL \
            --org $INFLUX_ORG \
            --host $INFLUX_HOST \
            --token $INFLUX_TOKEN

--- a/tomcat/readme.md
+++ b/tomcat/readme.md
@@ -11,7 +11,7 @@ This Dashboard offers you information about your Apache Tomcat instance. Current
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/tomcat/tomcat.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/tomcat/tomcat.yml
 ```
 
 ## Included Resources

--- a/vsphere/readme.md
+++ b/vsphere/readme.md
@@ -11,7 +11,7 @@ This Dashboard offers you information about your vSphere host. Uptime, CPU, RAM,
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/vsphere/vsphere.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/vsphere/vsphere.yml
 ```
 
 ## Included Resources

--- a/windows_system/README.md
+++ b/windows_system/README.md
@@ -9,7 +9,7 @@ This InfluxDB Template can be used to monitor your Windows System.
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/windows_system/windows_system.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/windows_system/windows_system.yml
 ```
 
 ### Included Resources

--- a/x509/readme.md
+++ b/x509/readme.md
@@ -11,7 +11,7 @@ This Dashboard is very simple but can help you with information about your x509 
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/x509/x509.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/x509/x509.yml
 ```
 
 ## Included Resources

--- a/zookeeper/readme.md
+++ b/zookeeper/readme.md
@@ -11,7 +11,7 @@ This Dashboard offers you information about your ZooKeeper. Almost all of the me
 If you have your InfluxDB credentials [configured in the CLI](Vhttps://v2.docs.influxdata.com/v2.0/reference/cli/influx/config/), you can install this template with:
 
 ```
-influx pkg -u https://raw.githubusercontent.com/influxdata/community-templates/master/zookeeper/zookeeper.yml
+influx apply -u https://raw.githubusercontent.com/influxdata/community-templates/master/zookeeper/zookeeper.yml
 ```
 
 ## Included Resources


### PR DESCRIPTION
all influx pkg commands are deprecated moving forward and will be sunset.

closes: #140