### PR TITLE
Revert changes to slack message call in fortnite template

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,10 @@ jobs:
     
       run: |
         cd /tmp
-        wget https://dl.influxdata.com/platform/nightlies/influx_nightly_linux_amd64.tar.gz
-        tar xvfz influx_nightly_linux_amd64.tar.gz
-        sudo cp influx_nightly_linux_amd64/{influx,influxd} /usr/local/bin/
-        influxd --reporting-disabled > /dev/null 2>&1 &
+        wget https://dl.influxdata.com/influxdb/releases/influxdb_2.0.0-beta.16_linux_amd64.tar.gz
+        tar xvfz influxdb_2.0.0-beta.16_linux_amd64.tar.gz
+        sudo cp influxdb_2.0.0-beta.16_linux_amd64/{influx,influxd} /usr/local/bin/
+        influxd --http-bind-address :8086 --reporting-disabled > /dev/null 2>&1 &
         until curl -s http://localhost:8086/health; do sleep 1; done
         influx setup -f -b dummy -o influxdata -u ci_user -p password
         cd $GITHUB_WORKSPACE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         sudo cp influxdb_2.0.0-beta.16_linux_amd64/{influx,influxd} /usr/local/bin/
         influxd --http-bind-address :8086 --reporting-disabled > /dev/null 2>&1 &
         until curl -s http://localhost:8086/health; do sleep 1; done
-        influx setup -f -b dummy -o influxdata -u ci_user -p password
+        influx setup --host http://localhost:8086 -f -b dummy -o influxdata -u ci_user -p password
         cd $GITHUB_WORKSPACE
         find $GITHUB_WORKSPACE \( ! -path '*/.*' \) -type f -name "*.yml" -print0 | while read -d $'\0' file
         do

--- a/fortnite/fn-template.yml
+++ b/fortnite/fn-template.yml
@@ -37,14 +37,13 @@ spec:
         import "strings"
         import "influxdata/influxdb/secrets"
 
+
+
         webhook = secrets.get(key: "SLACK_WEBHOOK")
         sendSlackMessage = (text) =>
         	(slack.message(
         		url: webhook,
-                token: "",
-        		username: "",
-        		workspace: "",
-        		iconEmoji: "",
+        		token: "",
         		channel: "",
         		text: text,
         		color: "good",


### PR DESCRIPTION
Reverts changes made to the enviro+ template in PR #181 that inadvertently affected the fortnite plugin