### PR TITLE
chore: convert code blocks to backticks

### DIFF
--- a/InfluxDBv2_Covid19_SouthAmerica/readme.md
+++ b/InfluxDBv2_Covid19_SouthAmerica/readme.md
@@ -1,8 +1,8 @@
-# COVID-19 Dashboard focused in South America Data. 
+# COVID-19 Dashboard focused in South America Data.
 
 Provided by: Ignacio Van Droogenbroeck
 
-This Dashboard graph information about COVID-19 focused in Argentina, Bolivia, Brasil, Chile, Paraguay and Uruguay. Current data, new cases, graph about totals of cases and deaths. Also overall worldwide information about cases and deaths.  
+This Dashboard graph information about COVID-19 focused in Argentina, Bolivia, Brasil, Chile, Paraguay and Uruguay. Current data, new cases, graph about totals of cases and deaths. Also overall worldwide information about cases and deaths.
 
 ![Dashboard Screenshot](screenshot.png)
 
@@ -30,13 +30,13 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_HOST` - The host running InfluxDB
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
     - `INFLUX_ORG` - The name of your Organization.
 
-As the bucket was provided in this template, you need to set the following environment data </code>export INFLUX_BUCKET=covid</code>. Also may requiere adjust the information about the location of the executables files and set the agent interval to at least 1h, this for not hit to the api too much and cause service disruption. 
+As the bucket was provided in this template, you need to set the following environment data ```export INFLUX_BUCKET=covid```. Also may requiere adjust the information about the location of the executables files and set the agent interval to at least 1h, this for not hit to the api too much and cause service disruption.
 
 ## Contact
 
@@ -44,6 +44,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/csgo/readme.md
+++ b/csgo/readme.md
@@ -30,12 +30,12 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
     - `INFLUX_ORG` - The name of your Organization.
     - `INFLUX_HOST` - The address of you InfluxDB
-    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: <code>INFLUX_BUCKET=mssql</code>
+    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: ```INFLUX_BUCKET=mssql```
 
 In order to use this dashboard you need to get an API key and your Steam User ID:
 
@@ -50,6 +50,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/haproxy/readme.md
+++ b/haproxy/readme.md
@@ -2,7 +2,7 @@
 
 Provided by: Ignacio Van Droogenbroeck
 
-This dashboard help you get metrics of your HAProxy instance. 
+This dashboard help you get metrics of your HAProxy instance.
 
 ![Dashboard Screenshot](screenshot.png)
 
@@ -29,13 +29,13 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
     - `INFLUX_ORG` - The name of your Organization.
     - `INFLUX_HOST` - The host where run InfluxDB
 
-In order to use this template, you need to specify the HAProxy instance, if you have one to monitor, you can pass as variable the name and port of the host. Ex <code>$ export haproxy_stats=http://localhost:10000/stats</code>
+In order to use this template, you need to specify the HAProxy instance, if you have one to monitor, you can pass as variable the name and port of the host. Ex ```$ export haproxy_stats=http://localhost:10000/stats```
 If you have more instances of HAProxy I recommend you to edit the haproxy.yml to add others hosts.
 
 ## Contact
@@ -44,6 +44,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/jboss_wildfly/readme.md
+++ b/jboss_wildfly/readme.md
@@ -29,16 +29,16 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your master token to get started.
     - `INFLUX_ORG` - The name of your Organization.
     - `INFLUX_HOST` - The address of you InfluxDB
-    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: <code>export INFLUX_BUCKET=jboss-wildfly</code>
+    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: ```export INFLUX_BUCKET=jboss-wildfly```
 
 In order to use this Dashboard, you need to specify the connection string to connect to the jBoss Wildfly / Jolokia instance as variable.
 
-ex: <code>$ export $JBOSS_CONNECTION_STRING=http://localhost:8080/jolokia</code>
+ex: ```$ export $JBOSS_CONNECTION_STRING=http://localhost:8080/jolokia```
 
 ## Contact
 
@@ -46,6 +46,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/mongodb/readme.md
+++ b/mongodb/readme.md
@@ -24,12 +24,12 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
     - 1 Telegraf Configuration: 'mongodb-config'
     - 1 Dashboards: 'MongoDB'
     - 1 bucket: 'mongodb'
-    - 1 label: 'mongodb' 
+    - 1 label: 'mongodb'
 
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_HOST` - Your InfluxDB host (ex:http://localhost:9999)
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
@@ -38,11 +38,11 @@ General instructions on using InfluxDB Templates can be found in the [use a temp
 
 In order to use this Dashboard, you need to specify the string connection to MongoDB instance as variable. Ex:
 
-<code>$ export MONGO_STRING_CONNECTION=mongodb://user:auth_key@10.10.3.30:27017</code>
+```$ export MONGO_STRING_CONNECTION=mongodb://user:auth_key@10.10.3.30:27017```
 
 Also, if you want to use the bucket include in this template. please, define the name bucket as variable too.
 
-<code>$ export INFLUX_BUCKET=mongodb</code>
+```$ export INFLUX_BUCKET=mongodb```
 
 ## Contact
 
@@ -50,6 +50,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/mssql/readme.md
+++ b/mssql/readme.md
@@ -30,12 +30,12 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
     - `INFLUX_ORG` - The name of your Organization.
     - `INFLUX_HOST` - The address of you InfluxDB
-    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: <code>INFLUX_BUCKET=mssql</code>
+    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: ```INFLUX_BUCKET=mssql```
 
 ## Additional Instructions For Azure DB
 
@@ -60,6 +60,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/mysql_mariadb/readme.md
+++ b/mysql_mariadb/readme.md
@@ -29,16 +29,16 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
     - `INFLUX_ORG` - The name of your Organization.
     - `INFLUX_HOST` - The address of you InfluxDB
-    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: <code>export INFLUX_BUCKET=mariadb</code>
+    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: ```export INFLUX_BUCKET=mariadb```
 
 In order to use this Dashboard, you need to specify the connection string to the mySQL/MariaDB instance as variable. The same needs to define user and password (read only recommended)
 
-ex: <code>$ export $MYSQL_CONNECTION_STRING=user@tcp(127.0.0.1:3306)/?tls=false</code>
+ex: ```$ export $MYSQL_CONNECTION_STRING=user@tcp(127.0.0.1:3306)/?tls=false```
 
 ## Contact
 
@@ -46,6 +46,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/postgresql/readme.md
+++ b/postgresql/readme.md
@@ -29,16 +29,16 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
     - `INFLUX_ORG` - The name of your Organization.
     - `INFLUX_HOST` - The address of you InfluxDB
-    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: <code>export INFLUX_BUCKET=postgres</code>
+    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: ```export INFLUX_BUCKET=postgres```
 
 In order to use this Dashboard, you need to specify the connection string to the Postgres instance as variable. The same needs to define user and password (read only recommended)
 
-ex: <code>$ export PSQL_STRING_CONNECTIONG=postgres://postgres:mysecretpassword@localhost:5432</code>
+ex: ```$ export PSQL_STRING_CONNECTIONG=postgres://postgres:mysecretpassword@localhost:5432```
 
 ## Contact
 
@@ -46,6 +46,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/speedtest/readme.md
+++ b/speedtest/readme.md
@@ -2,7 +2,7 @@
 
 Provided by: Ignacio Van Droogenbroeck
 
-This template offer a view of your Internet connection Speed. 
+This template offer a view of your Internet connection Speed.
 
 ![Dashboard Screenshot](screenshot.jpg)
 
@@ -29,13 +29,13 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
     - `INFLUX_ORG` - The name of your Organization.
     - `INFLUX_HOST` - The address of you InfluxDB
 
-In order to use this template, you must install speedtest-cli. If you're using Debian based distributions, you need to run <code>sudo apt install speedtest-cli</code>
+In order to use this template, you must install speedtest-cli. If you're using Debian based distributions, you need to run ```sudo apt install speedtest-cli```
 
 ## Contact
 
@@ -43,6 +43,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/vsphere/readme.md
+++ b/vsphere/readme.md
@@ -24,17 +24,17 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
     - 1 Telegraf Configuration
     - 1 Dashboards: vsphere.yml
     - 1 bucket: 'vsphere'
-    - 1 label: 'vsphere' 
+    - 1 label: 'vsphere'
 
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
     - `INFLUX_ORG` - The name of your Organization.
     - `INFLUX_HOST` - The address of you InfluxDB
-    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: <code>export INFLUX_BUCKET=vsphere</code>
+    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: ```export INFLUX_BUCKET=vsphere```
 
 In order to use this Dashboard, you need to specify as variable the address to the vSphere (EX: https://vsphere/sdk), also, you need to provide the username and password as variable too.
 
@@ -44,6 +44,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/x509/readme.md
+++ b/x509/readme.md
@@ -24,17 +24,17 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
     - 1 Telegraf Configuration
     - 1 Dashboards: x509.yml
     - 1 bucket: 'x509'
-    - 1 label: 'x509' 
+    - 1 label: 'x509'
 
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
     - `INFLUX_ORG` - The name of your Organization.
     - `INFLUX_HOST` - The address of you InfluxDB
-    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: <code>export INFLUX_BUCKET=x509</code>
+    - `INFLUX_BUCKET` - The name of the Bucket. If you going to use the bucket included, you need to export the variable. Ex: ```export INFLUX_BUCKET=x509```
 
 In order to use this template, before import, you need to specify the certificates you want monitor in the x509.yml file.
 
@@ -44,6 +44,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck

--- a/zookeeper/readme.md
+++ b/zookeeper/readme.md
@@ -29,16 +29,16 @@ influx apply -u https://raw.githubusercontent.com/influxdata/community-templates
 ## Setup Instructions
 
 General instructions on using InfluxDB Templates can be found in the [use a template](../docs/use_a_template.md) document.
-    
+
     Telegraf Configuration requires the following environment variables
     - `INFLUX_TOKEN` - The token with the permissions to read Telegraf configs and write data to the `telegraf` bucket. You can just use your operator token to get started.
     - `INFLUX_ORG` - The name of your Organization.
     - `INFLUX_HOST` - The address of you InfluxDB
     - `INFLUX_BUCKET` - The name of the Bucket. In this case, the bucket was included, so, you need to specify 'INFLUX_BUCKET=zookeeper'
-    
+
 In order to use this Dashboard, you need to specify the address to the ZooKeeper client (EX: https://localhost:2181) as variable 'ZOOKEEPER_HOST'
 
-<code>$ export ZOOKEEPER_HOST=https://localhost:2181</code>
+```$ export ZOOKEEPER_HOST=https://localhost:2181```
 
 ## Contact
 
@@ -46,6 +46,6 @@ Author: Ignacio Van Droogenbroeck
 
 Email: ignacio[at]vandroogenbroeck[dot]net
 
-Github and Gitlab user: @xe-nvdk 
+Github and Gitlab user: @xe-nvdk
 
 Influx Slack: Ignacio Van Droogenbroeck


### PR DESCRIPTION
Changes `<code>...</code>` blocks, which can't be rendered by markdown, into backticks: \`\`\`.

**Note**: My editor trims whitespace automatically. To view the diff without those changes, hit [this link](https://github.com/influxdata/community-templates/pull/185/files?w=1) or append `?w=1` to the diff.

#### Old:
![Screen Shot 2020-09-14 at 3 59 39 PM](https://user-images.githubusercontent.com/146112/93146407-951c8d80-f6a3-11ea-98ad-bb79dee3bc5e.png)

#### Improved:
![Screen Shot 2020-09-14 at 3 58 35 PM](https://user-images.githubusercontent.com/146112/93146411-98177e00-f6a3-11ea-926a-a632db880b5f.png)
