### PR TITLE
chore: add default 7 day retention policy to all templates

### DIFF
--- a/InfluxDBv2_Covid19_SouthAmerica/covid.yml
+++ b/InfluxDBv2_Covid19_SouthAmerica/covid.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: jolly-blackburn-e60001
     name: covid
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -609,139 +612,139 @@ spec:
            ## urls will be written to each interval.
            ## urls exp: http://127.0.0.1:9999
            urls = ["$INFLUX_HOST"]
-         
+
            ## Token for authentication.
            token = "$INFLUX_TOKEN"
-         
+
            ## Organization is the name of the organization you wish to write to; must exist.
            organization = "$INFLUX_ORG"
-         
+
            ## Destination bucket to write into.
            bucket = "$INFLUX_BUCKET"
-         
+
            [agent]
            interval = "3h"
-         
+
          [[inputs.exec]]
            ## Commands array
            commands = [
              "sh argentina.sh"
            ]
-         
+
            ## Timeout for each command to complete.
            timeout = "30s"
-         
+
            ## measurement name suffix (for separating different commands)
            name_suffix = "_argentina"
-         
+
            ## Data format to consume.
            ## Each data format has its own unique set of configuration options, read
            ## more about them here:
            ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
            data_format = "json"
-         
+
          [[inputs.exec]]
            ## Commands array
            commands = [
             "sh uruguay.sh"
            ]
-         
+
            ## Tind to complete.
            timeout = "30s"
-         
+
            ## measurement name suffix (for separating different commands)
            name_suffix = "_uruguay"
-         
+
            ## Data format to consume.
            ## Each data format has its own unique set of configuration options, read
            ## more about them here:
            ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
            data_format = "json"
-         
+
          [[inputs.exec]]
            ## Commands array
            commands = [
             "sh bolivia.sh"
            ]
-         
+
            ## Timeout for each command to complete.
            timeout = "30s"
-         
+
            ## measurement name suffix (for separating different commands)
            name_suffix = "_bolivia"
-         
+
            ## Data format to consume.
            ## Each data format has its own unique set of configuration options, read
            ## more about them here:
            ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
            data_format = "json"
-         
+
          [[inputs.exec]]
            ## Commands array
            commands = [
              "sh brasil.sh"
            ]
-         
+
            ## Timeout for each command to complete.
            timeout = "30s"
-         
+
            ## measurement name suffix (for separating different commands)
            name_suffix = "_brasil"
-         
+
            ## Data format to consume.
            ## Each data format has its own unique set of configuration options, read
            ## more about them here:
            ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
            data_format = "json"
-         
+
          [[inputs.exec]]
            ## Commands array
            commands = [
             "sh chile.sh"
            ]
-         
+
            ## Timeout for each command to complete.
            timeout = "30s"
-         
+
            ## measurement name suffix (for separating different commands)
            name_suffix = "_chile"
-         
+
            ## Data format to consume.
            ## Each data format has its own unique set of configuration options, read
            ## more about them here:
            ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
            data_format = "json"
-         
+
          [[inputs.exec]]
            ## Commands array
            commands = [
             "sh paraguay.sh"
            ]
-         
+
            ## Timeout for each command to complete.
            timeout = "30s"
-         
+
            ## measurement name suffix (for separating different commands)
            name_suffix = "_paraguay"
-         
+
            ## Data format to consume.
            ## Each data format has its own unique set of configuration options, read
            ## more about them here:
            ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
            data_format = "json"
-         
+
          [[inputs.exec]]
            ## Commands array
            commands = [
             "sh worldwide.sh"
            ]
-         
+
            ## Timeout for each command to complete.
            timeout = "30s"
-         
+
            ## measurement name suffix (for separating different commands)
            name_suffix = "_worldwide"
-         
+
            ## Data format to consume.
            ## Each data format has its own unique set of configuration options, read
            ## more about them here:

--- a/apex_legends/apex_legends_template.yml
+++ b/apex_legends/apex_legends_template.yml
@@ -9,12 +9,15 @@ spec:
 apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 metadata:
-    name: modest-nightingale-276001   
+    name: modest-nightingale-276001
 spec:
     associations:
       - kind: Label
-        name: adoring-golick-276003 
+        name: adoring-golick-276003
     name: apexlegends
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -427,8 +430,8 @@ spec:
     name: Apex Legends Telegraf
     associations:
       - kind: Label
-        name: adoring-golick-276003  
-    description: Apex Legends API Input  
+        name: adoring-golick-276003
+    description: Apex Legends API Input
     config: |
                   # Pull in global stats
                   [[inputs.file]]

--- a/csgo/csgo.yml
+++ b/csgo/csgo.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: optimistic-newton-b2f001
     name: csgo
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -1081,31 +1084,31 @@ spec:
             ## urls will be written to each interval.
             ## urls exp: http://127.0.0.1:9999
             urls = ["$INFLUX_HOST"]
-          
+
             ## Token for authentication.
             token = "$INFLUX_TOKEN"
-          
+
             ## Organization is the name of the organization you wish to write to; must exist.
             organization = "$INFLUX_ORG"
-          
+
             ## Destination bucket to write into.
             bucket = "$INFLUX_BUCKET"
-          
+
           [agent]
           interval = "30m"
-          
+
           [[inputs.exec]]
             ## Commands array
             commands = [
               "sh csgo.sh"
             ]
-          
+
             ## Timeout for each command to complete.
             timeout = "5s"
-          
+
             ## measurement name suffix (for separating different commands)
             name_suffix = "_csgo"
-          
+
             ## Data format to consume.
             ## Each data format has its own unique set of configuration options, read
             ## more about them here:

--- a/docker/docker.yml
+++ b/docker/docker.yml
@@ -102,6 +102,9 @@ metadata:
   name: relaxed-turing-d4d019
 spec:
   name: dave
+  retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: CheckThreshold

--- a/downsampling/buckets.yml
+++ b/downsampling/buckets.yml
@@ -4,6 +4,9 @@ metadata:
     name: telegraf-1d-bucket
 spec:
     name: telegraf_1d
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Bucket
@@ -11,6 +14,9 @@ metadata:
     name: telegraf-bucket
 spec:
     name: telegraf
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Bucket
@@ -18,6 +24,9 @@ metadata:
     name: telegraf-1h-bucket
 spec:
     name: telegraf_1h
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Bucket
@@ -25,6 +34,9 @@ metadata:
     name: telegraf-1m-bucket
 spec:
     name: telegraf_1m
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Bucket
@@ -32,3 +44,6 @@ metadata:
     name: telegraf-10m-bucket
 spec:
     name: telegraf_10m
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire

--- a/github/github.yml
+++ b/github/github.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: hopeful-banach-e04001
     name: github
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard

--- a/haproxy/haproxy.yml
+++ b/haproxy/haproxy.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: optimistic-shannon-5a2001
     name: haproxy
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard

--- a/jboss_wildfly/jboss_wildfly.yml
+++ b/jboss_wildfly/jboss_wildfly.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: inspiring-dirac-5a3001
     name: jboss-wildfly
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -650,79 +653,79 @@ spec:
          ## urls will be written to each interval.
          ## urls exp: http://127.0.0.1:9999
          urls = ["$INFLUX_HOST"]
-        
+
          ## Token for authentication.
          token = "$INFLUX_TOKEN"
-        
+
           ## Organization is the name of the organization you wish to write to; must exist.
          organization = "$INFLUX_ORG"
-        
+
           ## Destination bucket to write into.
          bucket = "$INFLUX_BUCKET"
-        
+
          [agent]
          interval = "1m"
-        
+
          [[inputs.jolokia2_agent]]
           urls = ["$JBOSS_CONNECTION_STRING"]
           name_prefix = "jboss."
-        
+
           ### JVM Generic
-        
+
          [[inputs.jolokia2_agent.metric]]
             name  = "OperatingSystem"
             mbean = "java.lang:type=OperatingSystem"
             paths = ["ProcessCpuLoad","SystemLoadAverage","SystemCpuLoad"]
-        
+
          [[inputs.jolokia2_agent.metric]]
             name  = "jvm_runtime"
             mbean = "java.lang:type=Runtime"
             paths = ["Uptime"]
-        
+
          [[inputs.jolokia2_agent.metric]]
             name  = "jvm_memory"
             mbean = "java.lang:type=Memory"
             paths = ["HeapMemoryUsage", "NonHeapMemoryUsage", "ObjectPendingFinalizationCount"]
-        
+
          [[inputs.jolokia2_agent.metric]]
             name     = "jvm_garbage_collector"
             mbean    = "java.lang:name=*,type=GarbageCollector"
             paths    = ["CollectionTime", "CollectionCount"]
             tag_keys = ["name"]
-        
+
          [[inputs.jolokia2_agent.metric]]
             name       = "jvm_memory_pool"
             mbean      = "java.lang:name=*,type=MemoryPool"
             paths      = ["Usage", "PeakUsage", "CollectionUsage"]
             tag_keys   = ["name"]
             tag_prefix = "pool_"
-        
+
           ### JBOSS
-        
+
          [[inputs.jolokia2_agent.metric]]
             name     = "connectors.http"
             mbean    = "jboss.as:https-listener=*,server=*,subsystem=undertow"
             paths    = ["bytesReceived","bytesSent","errorCount","requestCount"]
             tag_keys = ["server","https-listener"]
-        
+
          [[inputs.jolokia2_agent.metric]]
             name     = "connectors.http"
             mbean    = "jboss.as:http-listener=*,server=*,subsystem=undertow"
             paths    = ["bytesReceived","bytesSent","errorCount","requestCount"]
             tag_keys = ["server","http-listener"]
-        
+
          [[inputs.jolokia2_agent.metric]]
             name     = "datasource.jdbc"
             mbean    = "jboss.as:data-source=*,statistics=jdbc,subsystem=datasources"
             paths    = ["PreparedStatementCacheAccessCount","PreparedStatementCacheHitCount","PreparedStatementCacheMissCount"]
             tag_keys = ["data-source"]
-        
+
          [[inputs.jolokia2_agent.metric]]
             name     = "datasource.pool"
             mbean    = "jboss.as:data-source=*,statistics=pool,subsystem=datasources"
             paths    = ["AvailableCount","ActiveCount","MaxUsedCount"]
             tag_keys = ["data-source"]
-        
+
          [[inputs.cpu]]
             ## Whether to report per-cpu stats or not
             percpu = true
@@ -744,4 +747,3 @@ spec:
          [[inputs.processes]]
          [[inputs.swap]]
          [[inputs.system]]
-    

--- a/minio/minio.yml
+++ b/minio/minio.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: happy-maxwell-651001
     name: minio
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard

--- a/modbus/modbus.yml
+++ b/modbus/modbus.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: agitated-driscoll-46e001
     name: node8
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: CheckThreshold

--- a/mysql_mariadb/mysql_mariadb.yml
+++ b/mysql_mariadb/mysql_mariadb.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: cranky-ramanujan-708001
     name: mariadb
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard

--- a/postgresql/postgres.yml
+++ b/postgresql/postgres.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: flamboyant-dubinsky-332001
     name: postgres
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -548,24 +551,24 @@ spec:
           ## urls will be written to each interval.
           ## urls exp: http://127.0.0.1:9999
           urls = ["$INFLUX_HOST"]
-        
+
           ## Token for authentication.
           token = "$INFLUX_TOKEN"
-        
+
           ## Organization is the name of the organization you wish to write to; must exist.
           organization = "$INFLUX_ORG"
-        
+
           ## Destination bucket to write into.
           bucket = "$INFLUX_BUCKET"
-              
+
           [agent]
           interval = "1m"
-          
+
         [[inputs.postgresql]]
           # address = "postgres://postgres:mysecretpassword@localhost:5432"
           address = "$PSQL_STRING_CONNECTION"
           ignored_databases = ["template0", "template1"]
-        
+
         [[inputs.cpu]]
           ## Whether to report per-cpu stats or not
           percpu = true
@@ -575,15 +578,15 @@ spec:
           collect_cpu_time = false
           ## If true, compute and report the sum of all non-idle CPU states.
           report_active = false
-        
+
         [[inputs.disk]]
           ## By default stats will be gathered for all mount points.
           ## Set mount_points will restrict the stats to only the specified mount points.
           # mount_points = ["/"]
-        
+
           ## Ignore mount points by filesystem type.
           ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
-        
+
         # Read metrics about disk IO by device
         [[inputs.diskio]]
           ## By default, telegraf will gather stats for all devices including
@@ -611,8 +614,8 @@ spec:
           ## The typical use case is for LVM volumes, to get the VG/LV name instead of
           ## the near-meaningless DM-0 name.
           # name_templates = ["$ID_FS_LABEL","$DM_VG_NAME/$DM_LV_NAME"]
-        
+
         # Read metrics about memory usage
         [[inputs.mem]]
           # no configuration
-      
+

--- a/speedtest/speedtest.yml
+++ b/speedtest/speedtest.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: adoring-hellman-62a001
     name: speedtest
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -153,30 +156,30 @@ spec:
            ## Multiple URLs can be specified for a single cluster, only ONE of the
            ## urls will be written to each interval.
            ## urls exp: http://127.0.0.1:9999
-           urls = ["$INFLUX_HOST"]     
+           urls = ["$INFLUX_HOST"]
            ## Token for authentication.
-           token = "$INFLUX_TOKEN"         
+           token = "$INFLUX_TOKEN"
 
            ## Organization is the name of the organization you wish to write to; must exist.
-           organization = "$INFLUX_ORG"         
+           organization = "$INFLUX_ORG"
 
            ## Destination bucket to write into.
-           bucket = "speedtest"         
+           bucket = "speedtest"
 
            [agent]
-           interval = "1m"         
+           interval = "1m"
 
          [[inputs.exec]]
            ## Commands array
            commands = [
              "speedtest --json --single"
-           ]         
+           ]
 
            ## Timeout for each command to complete.
-           timeout = "90s"         
+           timeout = "90s"
 
            ## measurement name suffix (for separating different commands)
-           name_suffix = "_speedtest"         
+           name_suffix = "_speedtest"
 
            ## Data format to consume.
            ## Each data format has its own unique set of configuration options, read

--- a/tomcat/tomcat.yml
+++ b/tomcat/tomcat.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: terrifying-hodgkin-1cb001
     name: tomcat
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -270,7 +273,7 @@ kind: Telegraf
 metadata:
     name: apache-tomcat
 spec:
-    config: | 
+    config: |
          [[outputs.influxdb_v2]]
           ## The URLs of the InfluxDB cluster nodes.
           ##
@@ -310,5 +313,5 @@ spec:
             # insecure_skip_verify = false
     name: Apache Tomcat
     Description: Dashboard to monitor Apache Tomcat
-        
-         
+
+

--- a/vsphere/vsphere.yml
+++ b/vsphere/vsphere.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: distracted-yonath-5cb001
     name: vsphere
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -268,16 +271,16 @@ spec:
         # Environment variables can be used anywhere in this config file, simply surround
         # them with ${}. For strings the variable must be within quotes (ie, "${STR_VAR}"),
         # for numbers and booleans they should be plain (ie, ${INT_VAR}, ${BOOL_VAR})
-        
-        
+
+
         # Global tags can be specified here in key="value" format.
         [global_tags]
         # dc = "us-east-1" # will tag all metrics with dc=us-east-1
         # rack = "1a"
         ## Environment variables can be used as tags, and throughout the config file
         # user = "$USER"
-        
-        
+
+
         # Configuration for telegraf agent
         [agent]
         ## Default data collection interval for all inputs
@@ -285,23 +288,23 @@ spec:
         ## Rounds collection interval to 'interval'
         ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
         round_interval = true
-        
+
         ## Telegraf will send metrics to outputs in batches of at most
         ## metric_batch_size metrics.
         ## This controls the size of writes that Telegraf sends to output plugins.
         metric_batch_size = 1000
-        
+
         ## Maximum number of unwritten metrics per output.  Increasing this value
         ## allows for longer periods of output downtime without dropping metrics at the
         ## cost of higher maximum memory usage.
         metric_buffer_limit = 10000
-        
+
         ## Collection jitter is used to jitter the collection by a random amount.
         ## Each plugin will sleep for a random time within jitter before collecting.
         ## This can be used to avoid many plugins querying things like sysfs at the
         ## same time, which can have a measurable effect on the system.
         collection_jitter = "0s"
-        
+
         ## Default flushing interval for all outputs. Maximum flush_interval will be
         ## flush_interval + flush_jitter
         flush_interval = "10s"
@@ -309,7 +312,7 @@ spec:
         ## large write spikes for users running a large number of telegraf instances.
         ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
         flush_jitter = "0s"
-        
+
         ## By default or when set to "0s", precision will be set to the same
         ## timestamp order as the collection interval, with the maximum being 1s.
         ##   ie, when interval = "10s", precision will be "1s"
@@ -318,40 +321,40 @@ spec:
         ## service input to set the timestamp at the appropriate precision.
         ## Valid time units are "ns", "us" (or "µs"), "ms", "s".
         precision = ""
-        
+
         ## Log at debug level.
         # debug = false
         ## Log only error level messages.
         # quiet = false
-        
+
         ## Log target controls the destination for logs and can be one of "file",
         ## "stderr" or, on Windows, "eventlog".  When set to "file", the output file
         ## is determined by the "logfile" setting.
         # logtarget = "file"
-        
+
         ## Name of the file to be logged to when using the "file" logtarget.  If set to
         ## the empty string then logs are written to stderr.
         # logfile = ""
-        
+
         ## The logfile will be rotated after the time interval specified.  When set
         ## to 0 no time based rotation is performed.  Logs are rotated only when
         ## written to, if there is no log activity rotation may be delayed.
         # logfile_rotation_interval = "0d"
-        
+
         ## The logfile will be rotated when it becomes larger than the specified
         ## size.  When set to 0 no size based rotation is performed.
         # logfile_rotation_max_size = "0MB"
-        
+
         ## Maximum number of rotated archives to keep, any older logs are deleted.
         ## If set to -1, no archives are removed.
         # logfile_rotation_max_archives = 5
-        
+
         ## Override default hostname, if empty use os.Hostname()
         hostname = ""
         ## If set to true, do no set the "host" tag in the telegraf agent.
         omit_hostname = false
-        
-        
+
+
         ###############################################################################
         #                            OUTPUT PLUGINS                                   #
         ###############################################################################

--- a/x509/x509.yml
+++ b/x509/x509.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: heuristic-galileo-e56001
     name: x509
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -196,16 +199,16 @@ spec:
         # Environment variables can be used anywhere in this config file, simply surround
         # them with ${}. For strings the variable must be within quotes (ie, "${STR_VAR}"),
         # for numbers and booleans they should be plain (ie, ${INT_VAR}, ${BOOL_VAR})
-        
-        
+
+
         # Global tags can be specified here in key="value" format.
         [global_tags]
         # dc = "us-east-1" # will tag all metrics with dc=us-east-1
         # rack = "1a"
         ## Environment variables can be used as tags, and throughout the config file
         # user = "$USER"
-        
-        
+
+
         # Configuration for telegraf agent
         [agent]
         ## Default data collection interval for all inputs
@@ -213,23 +216,23 @@ spec:
         ## Rounds collection interval to 'interval'
         ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
         round_interval = true
-        
+
         ## Telegraf will send metrics to outputs in batches of at most
         ## metric_batch_size metrics.
         ## This controls the size of writes that Telegraf sends to output plugins.
         metric_batch_size = 1000
-        
+
         ## Maximum number of unwritten metrics per output.  Increasing this value
         ## allows for longer periods of output downtime without dropping metrics at the
         ## cost of higher maximum memory usage.
         metric_buffer_limit = 10000
-        
+
         ## Collection jitter is used to jitter the collection by a random amount.
         ## Each plugin will sleep for a random time within jitter before collecting.
         ## This can be used to avoid many plugins querying things like sysfs at the
         ## same time, which can have a measurable effect on the system.
         collection_jitter = "0s"
-        
+
         ## Default flushing interval for all outputs. Maximum flush_interval will be
         ## flush_interval + flush_jitter
         flush_interval = "10s"
@@ -237,7 +240,7 @@ spec:
         ## large write spikes for users running a large number of telegraf instances.
         ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
         flush_jitter = "0s"
-        
+
         ## By default or when set to "0s", precision will be set to the same
         ## timestamp order as the collection interval, with the maximum being 1s.
         ##   ie, when interval = "10s", precision will be "1s"
@@ -246,40 +249,40 @@ spec:
         ## service input to set the timestamp at the appropriate precision.
         ## Valid time units are "ns", "us" (or "µs"), "ms", "s".
         precision = ""
-        
+
         ## Log at debug level.
         # debug = false
         ## Log only error level messages.
         # quiet = false
-        
+
         ## Log target controls the destination for logs and can be one of "file",
         ## "stderr" or, on Windows, "eventlog".  When set to "file", the output file
         ## is determined by the "logfile" setting.
         # logtarget = "file"
-        
+
         ## Name of the file to be logged to when using the "file" logtarget.  If set to
         ## the empty string then logs are written to stderr.
         # logfile = ""
-        
+
         ## The logfile will be rotated after the time interval specified.  When set
         ## to 0 no time based rotation is performed.  Logs are rotated only when
         ## written to, if there is no log activity rotation may be delayed.
         # logfile_rotation_interval = "0d"
-        
+
         ## The logfile will be rotated when it becomes larger than the specified
         ## size.  When set to 0 no size based rotation is performed.
         # logfile_rotation_max_size = "0MB"
-        
+
         ## Maximum number of rotated archives to keep, any older logs are deleted.
         ## If set to -1, no archives are removed.
         # logfile_rotation_max_archives = 5
-        
+
         ## Override default hostname, if empty use os.Hostname()
         hostname = ""
         ## If set to true, do no set the "host" tag in the telegraf agent.
         omit_hostname = false
-        
-        
+
+
         ###############################################################################
         #                            OUTPUT PLUGINS                                   #
         ###############################################################################

--- a/zookeeper/zookeeper.yml
+++ b/zookeeper/zookeeper.yml
@@ -15,6 +15,9 @@ spec:
       - kind: Label
         name: sloppy-tesla-708001
     name: zookeeper
+    retentionRules:
+    - everySeconds: 2.592e+6
+      type: expire
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -1045,4 +1048,4 @@ spec:
           ## If false, skip chain & host verification
           # insecure_skip_verify = true
 
-    
+


### PR DESCRIPTION
When installing the covid template, this is the resulting bucket:

![Screen Shot 2020-09-15 at 9 59 32 AM](https://user-images.githubusercontent.com/146112/93241451-33f3c900-f73a-11ea-8db6-df71f2896bd7.png)

my editor trims whitespace. to ignore the space changes in this diff: [add ?w=1 to the files url](https://github.com/influxdata/community-templates/pull/186/files?w=1)
