### PR TITLE
Update Rasp Pi template

### DIFF
--- a/raspberry-pi/raspberry-pi-system.yml
+++ b/raspberry-pi/raspberry-pi-system.yml
@@ -55,7 +55,6 @@ kind: Bucket
 metadata:
   name: heuristic-sinoussi-d7d017
 spec:
-  associations:
       associations:
       - kind: Label
         name: tender-wu-ecc001
@@ -223,7 +222,7 @@ spec:
                 from(bucket: v.bucket)
                   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
                   |> filter(fn: (r) => r["host"] == v.linux_host)
-                  |> filter(fn: (r) => r["_measurement"] == "gpu_temperature")
+                  |> filter(fn: (r) => r["_measurement"] == "temperature_gpu")
                   |> filter(fn: (r) => r["_field"] == "value")
                   |> last()
                   |> yield(name: "last")
@@ -542,8 +541,8 @@ spec:
         [[inputs.system]]
 
         [[inputs.exec]]
-          commands = ["/opt/vc/bin/vcgencmd measure_temp"]
-          name_override = "gpu_temperature"
+          commands = ["/usr/bin/vcgencmd measure_temp"]
+          name_override = "temperature_gpu"
           data_format = "grok"
           grok_patterns = ["%{NUMBER:value:float}"]
 

--- a/raspberry-pi/readme.md
+++ b/raspberry-pi/readme.md
@@ -44,27 +44,28 @@ General instructions on using InfluxDB Templates can be found in the [use a temp
     
   You may need to logout/log back in for this to take effect.  If running Ubuntu on Raspberry Pi 400, a reboot may be necessary.
   
-- Check the location of `vcgencmd` on your Raspberry Pi using
+- You may need to modify the telegraf configuration to reflect the location of your `vcgencmd`.  Currently, the telegraf configuration is set for
+  Ubuntu (Groovy Gorilla):
+  
+    ```
+    [[inputs.exec]]
+      commands = ["/usr/bin/vcgencmd measure_temp"]
+      name_override = "temperature_gpu"
+      data_format = "grok"
+      grok_patterns = ["%{NUMBER:value:float}"]
+    ```
+  
+  You can check the location of `vcgencmd` on your Raspberry Pi using:
     
     ```sh
     which vcgencmd
     ```
-  You may need to change the telegraf configuration to reflect the location of your `vcgencmd`.  Currently, the telegraf configuration is set for
-  Ubuntu (Groovy Gorilla):
   
-  ```
-  [[inputs.exec]]
-  commands = ["/usr/bin/vcgencmd measure_temp"]
-  name_override = "temperature_gpu"
-  data_format = "grok"
-  grok_patterns = ["%{NUMBER:value:float}"]
-  ```
+  Typically on Raspberry Pi OS, the `commands` line should be :
   
-  On Raspberry Pi OS, modify the `commands` line to:
-  
-  ```
-  commands = ["/opt/vc/bin/vcgencmd measure_temp"]
-  ```  
+    ```
+    commands = ["/opt/vc/bin/vcgencmd measure_temp"]
+    ```  
   
 Telegraf configuration requires the following environment variables:
 

--- a/raspberry-pi/readme.md
+++ b/raspberry-pi/readme.md
@@ -41,7 +41,31 @@ General instructions on using InfluxDB Templates can be found in the [use a temp
     sudo usermod -a -G video telegraf
     sudo -u telegraf vcgencmd measure_temp
     ```
-
+    
+  You may need to logout/log back in for this to take effect.  If running Ubuntu on Raspberry Pi 400, a reboot may be necessary.
+  
+- Check the location of `vcgencmd` on your Raspberry Pi using
+    
+    ```sh
+    which vcgencmd
+    ```
+  You may need to change the telegraf configuration to reflect the location of your `vcgencmd`.  Currently, the telegraf configuration is set for
+  Ubuntu (Groovy Gorilla):
+  
+  ```
+  [[inputs.exec]]
+  commands = ["/usr/bin/vcgencmd measure_temp"]
+  name_override = "temperature_gpu"
+  data_format = "grok"
+  grok_patterns = ["%{NUMBER:value:float}"]
+  ```
+  
+  On Raspberry Pi OS, modify the `commands` line to:
+  
+  ```
+  commands = ["/opt/vc/bin/vcgencmd measure_temp"]
+  ```  
+  
 Telegraf configuration requires the following environment variables:
 
 - `INFLUX_HOST` - The URL of your influxdb server.


### PR DESCRIPTION
Fixed 3 issues:

label association with bucket
gpu_temperature -> temperature_gpu to be more consistent with other gpu temp data gathering (see nvidia_smi)
change location of vcgencmd -> /usr/bin for Rasp PI 400  running groovy gorilla

and updated Readme