### PR TITLE
Removing unnecessary option and fixing conversion

### DIFF
--- a/speedtest/speedtest.yml
+++ b/speedtest/speedtest.yml
@@ -202,7 +202,7 @@ spec:
                   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
                   |> filter(fn: (r) => r["_measurement"] == "exec_speedtest")
                   |> filter(fn: (r) => r["_field"] == "download_bandwidth")
-                  |> map(fn: (r) => ({ r with _value: r._value / 100000.0 }))
+                  |> map(fn: (r) => ({ r with _value: r._value / 125000.0 }))
                   |> yield(name: "last")
         shade: true
         suffix: ' Mb/s'
@@ -236,7 +236,7 @@ spec:
                   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
                   |> filter(fn: (r) => r["_measurement"] == "exec_speedtest")
                   |> filter(fn: (r) => r["_field"] == "upload_bandwidth")
-                  |> map(fn: (r) => ({ r with _value: r._value / 100000.0 }))
+                  |> map(fn: (r) => ({ r with _value: r._value / 125000.0 }))
                   |> yield(name: "last")
         shade: true
         suffix: ' Mb/s'
@@ -280,7 +280,7 @@ spec:
 
           [[inputs.exec]]
           ## Commands array
-          commands = ["speedtest --format=json-pretty -u Mbps"]
+          commands = ["speedtest --format=json-pretty"]
 
           ## Timeout for each command to complete.
           timeout = "90s"


### PR DESCRIPTION
First of all, thanks for these excellent templates.

I've applied two small fixes in this PR.

The first one is removing the unnecessary `-u Mbps` option in the command. As per the docs, this option is only applicable for the `human-readable` output.

The second one is a fix in the download and upload conversion. The output bandwidth for both download and upload is returned in bytes from the Speedtest cli. In order to have it in megabit per second, which matches the suffix `Mb/s` used in the template, we need to divide it by `125000` instead of `100000`.