### PR TITLE
fix: Check length of possibly empty array

### DIFF
--- a/influxdb2_operational_monitoring/influxdb2_operational_monitoring.yml
+++ b/influxdb2_operational_monitoring/influxdb2_operational_monitoring.yml
@@ -108,11 +108,12 @@ spec:
                   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
                   |> filter(fn: (r) => r["_measurement"] == "runs")
                   |> filter(fn: (r) => r["_field"] == "logs")
-                  |> map(fn: (r) => {
-                     ind = regexp.findStringIndex(r: /name: \\\\\\".+?\\\\\\"/, v: r._value)
-                     finalstring = strings.trimSuffix(v: strings.trimPrefix(v: strings.substring(end: ind[1], start: ind[0], v: r._value ), prefix: "name: \\\\\\\""), suffix: "\\\\\\\"")
-                     return {r with name: finalstring }
-                  }
+                  |> map(
+                    fn: (r) => {
+                      ind = regexp.findStringIndex(r: /name: \\\\\\".+?\\\\\\"/, v: r._value)
+                      finalstring = if length(arr: ind) > 1 then strings.trimSuffix(v: strings.trimPrefix(v: strings.substring(end: ind[1], start: ind[0], v: r._value ), prefix: "name: \\\\\\\""), suffix: "\\\\\\\"") else "none"
+                      return {r with name: finalstring }
+                    }
                   )
                   |> group(columns: ["_start"])
                   |> count()


### PR DESCRIPTION
Checks the length of a possibly empty array and provides a default value of `"none"` if `length <= 1`.

Opened as part of https://github.com/influxdata/idpe/issues/9950