### PR TITLE
Took out '2'

### DIFF
--- a/usage_dashboard/readme.md
+++ b/usage_dashboard/readme.md
@@ -1,4 +1,4 @@
-# Cloud 2 Usage Dashboard
+# InfluxDb Cloud Usage Dashboard
 
 Provided by: InfluxData
 


### PR DESCRIPTION
We want to steer away from 'cloud 2' vs 'cloud 1' and just brand it as 'cloud'.