### PR TITLE
Missing sort means Data In Graph can look like

### DIFF
--- a/usage_dashboard/usage_dashboard.yml
+++ b/usage_dashboard/usage_dashboard.yml
@@ -136,6 +136,7 @@ spec:
                     |> group()
                     |> keep(columns: ["_value", "_field", "_time"])
                     |> fill(column: "_value", value: 0)
+                    |> sort(columns: ["_time"], desc: true)
                     |> map(fn: (r) =>
                       ({r with
                         write_mb: math.round(x: float(v: r._value) / 10000.0) / 100.0


### PR DESCRIPTION
See image in Influx Community Slack https://influxcommunity.slack.com/archives/CJ2NXC6A2/p1653084854791499 + am not sure if it's required on remaining graphs yet/too.